### PR TITLE
Build luajit as static library and fix install targets of openssl and raknet so all artifacts are gathered in the install target directory

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -30,13 +30,12 @@ jobs:
       - name: Configure
         run: |
           cd darkspore_server
-          cmake . -B build -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -Wno-narrowing"
+          cmake . -B build -DCMAKE_INSTALL_PREFIX=./AppDir/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -Wno-narrowing"
 
       - name: Build
         run: |
           cd darkspore_server
-          cmake --build build
-          DESTDIR=AppDir cmake --install build
+          cmake --build build --target install
 
       - uses: actions/upload-artifact@v4
         with:
@@ -52,7 +51,7 @@ jobs:
       - name: Build the AppImage
         run: |
           cd darkspore_server
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(find $(pwd)/build/_deps -maxdepth 3 -mindepth 1 -type d | tr '\n' ':')
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(pwd)/AppDir/usr/bin
           ./linuxdeploy-x86_64.AppImage --list-plugins
           ./linuxdeploy-x86_64.AppImage --appdir AppDir --output appimage
           rm ./linuxdeploy-x86_64.AppImage

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -44,22 +44,13 @@ jobs:
         run: |
           cd darkspore_server
           export PATH=/c/Users/runneradmin/nasm:$PATH
-          cmake . -B build -G "Visual Studio 17 2022" -DCMAKE_PREFIX_PATH="C:\\hostedtoolcache\\windows\\perl\\5.30.3-thr\\x64\\bin"
+          cmake . -B build -G "Visual Studio 17 2022" -DCMAKE_PREFIX_PATH="C:\\hostedtoolcache\\windows\\perl\\5.30.3-thr\\x64\\bin" -DCMAKE_INSTALL_PREFIX=./dist
 
       - name: Build
         run: |
           cd darkspore_server/build
           export PATH=/c/Users/runneradmin/nasm:$PATH
-          cmake --build . --config Release
-
-      - name: Preparing artifacts
-        run: |
-          cd darkspore_server
-          mkdir dist
-          mv build/Release/recap_server.exe ./dist/
-          mv build/_deps/openssl-source-build/*.dll ./dist/
-          mv build/_deps/luajit-src/src/*.dll ./dist/
-          mv build/_deps/raknet-build/Lib/DLL/Release/*.dll ./dist/
+          cmake --build . --config Release --target install
 
       - uses: actions/upload-artifact@v4
         with:

--- a/darkspore_server/CMakeLists.txt
+++ b/darkspore_server/CMakeLists.txt
@@ -27,6 +27,12 @@ if(MSVC)
     target_compile_options(recap_server PRIVATE $<$<CONFIG:Debug>:/bigobj>)
 endif()
 
+include(GNUInstallDirs)
+install(TARGETS recap_server
+    EXPORT recap-targets
+    RUNTIME
+        DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 # Boost
 set(BOOST_INCLUDE_LIBRARIES "asio;bind;regex;beast")
 CPMAddPackage(
@@ -52,10 +58,13 @@ target_include_directories(recap_server PRIVATE "${rapidjson_SOURCE_DIR}/include
 
 # OpenSSL
 CPMAddPackage(
-    GIT_REPOSITORY https://github.com/jimmy-park/openssl-cmake.git
-    GIT_TAG 5e5cef2e3c1713cc775ffe490bd0ff1c12a7ced7
+    GIT_REPOSITORY https://github.com/r0ptr/openssl-cmake.git
+    GIT_TAG 74ec40cedab235d566d4835a85fda5a0b02598df
     OPTIONS "BUILD_SHARED_LIBS ON"
             "OPENSSL_TARGET_VERSION 1.1.1b"
+            "OPENSSL_INSTALL ON"
+            "OPENSSL_INSTALL_TARGET install_sw"
+            "OPENSSL_CONFIGURE_OPTIONS --prefix=${CMAKE_INSTALL_PREFIX}"
             "OPENSSL_ENABLE_PARALLEL OFF"
             "OPENSSL_BUILD_VERBOSE ON"
             "OPENSSL_CONFIGURE_VERBOSE ON")
@@ -68,20 +77,17 @@ CPMAddPackage(
     VERSION 2.1.0-beta3
     DOWNLOAD_ONLY YES)
 if(luajit_ADDED)
-    add_library(luajit SHARED IMPORTED)
+    add_library(luajit STATIC IMPORTED)
     file(GLOB_RECURSE LUAJIT_SOURCES "${luajit_SOURCE_DIR}/src/*.h" "${luajit_SOURCE_DIR}/src/*.c")
 
     if(MSVC)
         include(cmake/get_findvcvars.cmake)
         find_package(Vcvars REQUIRED)
-        set(LUAJIT_BUILD_COMMAND ${Vcvars_LAUNCHER} ${luajit_SOURCE_DIR}/src/msvcbuild.bat)
-        set(LUAJIT_BUILD_OUTPUT ${luajit_SOURCE_DIR}/src/lua51.dll)
-        set_target_properties(luajit PROPERTIES IMPORTED_IMPLIB ${luajit_SOURCE_DIR}/src/lua51.lib)
+        set(LUAJIT_BUILD_COMMAND ${Vcvars_LAUNCHER} ${luajit_SOURCE_DIR}/src/msvcbuild.bat static)
+        set(LUAJIT_BUILD_OUTPUT ${luajit_SOURCE_DIR}/src/lua51.lib)
     else()
         set(LUAJIT_BUILD_COMMAND make)
-        set(LUAJIT_BUILD_OUTPUT ${luajit_SOURCE_DIR}/src/libluajit.so)
-        set(LUAJIT_SYMLINK1 ${luajit_SOURCE_DIR}/src/libluajit-5.1.so)
-        set(LUAJIT_SYMLINK2 ${luajit_SOURCE_DIR}/src/libluajit-5.1.so.2)
+        set(LUAJIT_BUILD_OUTPUT ${luajit_SOURCE_DIR}/src/libluajit.a)
     endif()
 
     set_target_properties(luajit PROPERTIES IMPORTED_LOCATION ${LUAJIT_BUILD_OUTPUT})
@@ -91,20 +97,9 @@ if(luajit_ADDED)
         DEPENDS ${LUAJIT_SOURCES}
         WORKING_DIRECTORY ${luajit_SOURCE_DIR}/src
         VERBATIM)
-
-    if (UNIX AND NOT APPLE)
-        add_custom_command(
-            OUTPUT ${LUAJIT_SYMLINK1} ${LUAJIT_SYMLINK2}
-            COMMAND ln -sf ${LUAJIT_BUILD_OUTPUT} ${LUAJIT_SYMLINK1}
-            COMMAND ln -sf ${LUAJIT_BUILD_OUTPUT} ${LUAJIT_SYMLINK2}
-            DEPENDS ${LUAJIT_BUILD_OUTPUT}
-            VERBATIM)
-    endif()
-
-    add_custom_target(luajit-build DEPENDS ${LUAJIT_BUILD_OUTPUT} ${LUAJIT_SYMLINK1} ${LUAJIT_SYMLINK2})
+    add_custom_target(luajit-build DEPENDS ${LUAJIT_BUILD_OUTPUT})
     add_dependencies(luajit luajit-build)
     target_include_directories(luajit SYSTEM INTERFACE $<BUILD_INTERFACE:${luajit_SOURCE_DIR}/src>)
-
     target_link_libraries(recap_server PRIVATE luajit)
 endif()
 
@@ -163,11 +158,7 @@ if(raknet_ADDED)
     execute_process(COMMAND git apply --ignore-whitespace --verbose ${RAKNET_PATCH} WORKING_DIRECTORY ${raknet_SOURCE_DIR})
 
     add_subdirectory(${raknet_SOURCE_DIR} ${raknet_BINARY_DIR})
-    if(WIN32 AND NOT UNIX)
-        target_link_libraries(recap_server PRIVATE DLL)
-    else()
-        target_link_libraries(recap_server PRIVATE RakNetDynamic)
-    endif()
+    target_link_libraries(recap_server PRIVATE RakNet)
 endif()
 
 if (UNIX AND NOT APPLE)

--- a/darkspore_server/cmake/patches/RakNet-3.902.patch
+++ b/darkspore_server/cmake/patches/RakNet-3.902.patch
@@ -70,10 +70,10 @@ index e15e1b6..098f764 100644
  add_subdirectory(DLL)
 \ No newline at end of file
 diff --git a/Lib/DLL/CMakeLists.txt b/Lib/DLL/CMakeLists.txt
-index 472dabd..23f1478 100644
+index 472dabd..cec46a6 100644
 --- a/Lib/DLL/CMakeLists.txt
 +++ b/Lib/DLL/CMakeLists.txt
-@@ -1,18 +1,19 @@
+@@ -1,18 +1,25 @@
 -cmake_minimum_required(VERSION 2.6)
 -project(DLL)
 +cmake_minimum_required(VERSION 3.0)
@@ -87,21 +87,35 @@ index 472dabd..23f1478 100644
 +	SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D WIN32 /D _RAKNET_DLL /D _CRT_NONSTDC_NO_DEPRECATE /D _CRT_SECURE_NO_DEPRECATE ")
  ENDIF(WIN32 AND NOT UNIX)
  
- IF(WIN32 AND NOT UNIX)
- 	add_library(DLL SHARED ${ALL_CPP_SRCS} ${ALL_HEADER_SRCS} readme.txt)
- 	target_link_libraries (DLL ${RAKNET_LIBRARY_LIBS})
-+	target_include_directories (DLL PUBLIC $<BUILD_INTERFACE:${RakNet_SOURCE_DIR}/Source>)
- ELSE(WIN32 AND NOT UNIX)
- 	add_library(RakNetDynamic SHARED ${ALL_CPP_SRCS} ${ALL_HEADER_SRCS} readme.txt)
- 	target_link_libraries (RakNetDynamic ${RAKNET_LIBRARY_LIBS})
-+	target_include_directories (RakNetDynamic PUBLIC $<BUILD_INTERFACE:${RakNet_SOURCE_DIR}/Source>)
- 	INSTALL(TARGETS RakNetDynamic DESTINATION ${RakNet_SOURCE_DIR}/Lib/DLL)
- ENDIF(WIN32 AND NOT UNIX)
+-IF(WIN32 AND NOT UNIX)
+-	add_library(DLL SHARED ${ALL_CPP_SRCS} ${ALL_HEADER_SRCS} readme.txt)
+-	target_link_libraries (DLL ${RAKNET_LIBRARY_LIBS})
+-ELSE(WIN32 AND NOT UNIX)
+-	add_library(RakNetDynamic SHARED ${ALL_CPP_SRCS} ${ALL_HEADER_SRCS} readme.txt)
+-	target_link_libraries (RakNetDynamic ${RAKNET_LIBRARY_LIBS})
+-	INSTALL(TARGETS RakNetDynamic DESTINATION ${RakNet_SOURCE_DIR}/Lib/DLL)
+-ENDIF(WIN32 AND NOT UNIX)
++include(GNUInstallDirs)
++
++add_library(RakNet SHARED ${ALL_CPP_SRCS} ${ALL_HEADER_SRCS})
++target_link_libraries (RakNet ${RAKNET_LIBRARY_LIBS})
++target_include_directories (RakNet PUBLIC $<BUILD_INTERFACE:${RakNet_SOURCE_DIR}/Source>)
++install(TARGETS RakNet
++	EXPORT RakNet-targets
++	RUNTIME
++		DESTINATION ${CMAKE_INSTALL_BINDIR}
++	LIBRARY
++		DESTINATION ${CMAKE_INSTALL_LIBDIR}
++	ARCHIVE
++		DESTINATION ${CMAKE_INSTALL_LIBDIR}
++	PUBLIC_HEADER
++		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 diff --git a/Lib/LibStatic/CMakeLists.txt b/Lib/LibStatic/CMakeLists.txt
-index dd2d5d2..7c809fe 100644
+index dd2d5d2..0a5d78f 100644
 --- a/Lib/LibStatic/CMakeLists.txt
 +++ b/Lib/LibStatic/CMakeLists.txt
-@@ -1,10 +1,9 @@
+@@ -1,27 +1,20 @@
 -cmake_minimum_required(VERSION 2.6)
 -project(LibStatic)
 +cmake_minimum_required(VERSION 3.0)
@@ -111,26 +125,32 @@ index dd2d5d2..7c809fe 100644
  FILE(GLOB ALL_CPP_SRCS ${RakNet_SOURCE_DIR}/Source/*.cpp)
  
 -include_directories(${RakNet_SOURCE_DIR}/Source) 
- IF(WIN32 AND NOT UNIX)
- 	add_library(LibStatic STATIC ${ALL_CPP_SRCS} ${ALL_HEADER_SRCS} readme.txt)
- ELSE(WIN32 AND NOT UNIX)
-@@ -12,13 +11,15 @@ ELSE(WIN32 AND NOT UNIX)
- ENDIF(WIN32 AND NOT UNIX)
+-IF(WIN32 AND NOT UNIX)
+-	add_library(LibStatic STATIC ${ALL_CPP_SRCS} ${ALL_HEADER_SRCS} readme.txt)
+-ELSE(WIN32 AND NOT UNIX)
+-	add_library(RakNetStatic STATIC ${ALL_CPP_SRCS} ${ALL_HEADER_SRCS} readme.txt)
+-ENDIF(WIN32 AND NOT UNIX)
++add_library(RakNetStatic STATIC ${ALL_CPP_SRCS} ${ALL_HEADER_SRCS})
  
  IF(WIN32 AND NOT UNIX)
 -	SET( CMAKE_CXX_FLAGS "/D WIN32 /D _RAKNET_LIB /D _CRT_NONSTDC_NO_DEPRECATE /D _CRT_SECURE_NO_DEPRECATE ")
 +	SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D WIN32 /D _RAKNET_LIB /D _CRT_NONSTDC_NO_DEPRECATE /D _CRT_SECURE_NO_DEPRECATE ")
  ENDIF(WIN32 AND NOT UNIX)
  
++target_include_directories (RakNetStatic PUBLIC $<BUILD_INTERFACE:${RakNet_SOURCE_DIR}/Source>)
++target_link_libraries (RakNetStatic ${RAKNET_LIBRARY_LIBS})
++
  IF(WIN32 AND NOT UNIX)
-+	target_include_directories (LibStatic PUBLIC $<BUILD_INTERFACE:${RakNet_SOURCE_DIR}/Source>)
- 	target_link_libraries (LibStatic ${RAKNET_LIBRARY_LIBS})
- 	set_target_properties(LibStatic PROPERTIES STATIC_LIBRARY_FLAGS "/NODEFAULTLIB:\"LIBCD.lib LIBCMTD.lib MSVCRT.lib\"" )
- ELSE(WIN32 AND NOT UNIX)
-+	target_include_directories (RakNetStatic PUBLIC $<BUILD_INTERFACE:${RakNet_SOURCE_DIR}/Source>)
- 	target_link_libraries (RakNetStatic ${RAKNET_LIBRARY_LIBS})
- 	INSTALL(TARGETS RakNetStatic DESTINATION ${RakNet_SOURCE_DIR}/Lib/LibStatic)
- 	INSTALL(FILES ${ALL_HEADER_SRCS} DESTINATION ${RakNet_SOURCE_DIR}/include/raknet)
+-	target_link_libraries (LibStatic ${RAKNET_LIBRARY_LIBS})
+-	set_target_properties(LibStatic PROPERTIES STATIC_LIBRARY_FLAGS "/NODEFAULTLIB:\"LIBCD.lib LIBCMTD.lib MSVCRT.lib\"" )
+-ELSE(WIN32 AND NOT UNIX)
+-	target_link_libraries (RakNetStatic ${RAKNET_LIBRARY_LIBS})
+-	INSTALL(TARGETS RakNetStatic DESTINATION ${RakNet_SOURCE_DIR}/Lib/LibStatic)
+-	INSTALL(FILES ${ALL_HEADER_SRCS} DESTINATION ${RakNet_SOURCE_DIR}/include/raknet)
++	set_target_properties(RakNetStatic PROPERTIES STATIC_LIBRARY_FLAGS "/NODEFAULTLIB:\"LIBCD.lib LIBCMTD.lib MSVCRT.lib\"" )
+ ENDIF(WIN32 AND NOT UNIX)
+ 
+ 
 diff --git a/Source/DS_BinarySearchTree.h b/Source/DS_BinarySearchTree.h
 index 49aad44..af3ccd2 100644
 --- a/Source/DS_BinarySearchTree.h


### PR DESCRIPTION
- Switch to static luajit build
- Fix install target of OpenSSL, RakNet and recap_server (openssl PR is sent, until accepted or solved otherwise, we can use the patched repo)
- Adapt workflows to rely on normal cmake install routes to gather build artifacts