### PR TITLE
Disable the non-deterministic parts of the build process to get the exact same binaries for the same set of inputs

### DIFF
--- a/darkspore_server/CMakeLists.txt
+++ b/darkspore_server/CMakeLists.txt
@@ -28,6 +28,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${RECAP_HEADERS} ${RECAP_SOU
 target_include_directories(recap_server PRIVATE source)
 if(MSVC)
     target_compile_options(recap_server PRIVATE $<$<CONFIG:Debug>:/bigobj>)
+    set_target_properties(recap_server PROPERTIES LINK_FLAGS "/SUBSYSTEM:CONSOLE /INCREMENTAL:NO /Brepro")
 endif()
 
 # Boost

--- a/darkspore_server/CMakeLists.txt
+++ b/darkspore_server/CMakeLists.txt
@@ -10,6 +10,8 @@ set(CMAKE_CXX_EXTENSIONS ON)
 
 project(recap_server VERSION 1.0.0)
 
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 # CPM package manager setup
 include(cmake/get_cpm.cmake)
 
@@ -21,7 +23,8 @@ add_definitions(-DBOOST_NETWORK_ENABLE_HTTPS -DBOOST_ASIO_DISABLE_CONCEPTS)
 add_definitions(-DRAPIDJSON_HAS_STDSTRING)
 add_definitions(-DSOL_STRINGS_ARE_NUMBERS=1 -DSOL_SAFE_FUNCTION=1 -DSOL_LUAJIT=1 -DSOL_EXCEPTIONS_SAFE_PROPAGATION=1)
 
-add_executable(recap_server ${RECAP_SOURCES} ${RECAP_SOURCES})
+add_executable(recap_server ${RECAP_HEADERS} ${RECAP_SOURCES})
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${RECAP_HEADERS} ${RECAP_SOURCES})
 target_include_directories(recap_server PRIVATE source)
 if(MSVC)
     target_compile_options(recap_server PRIVATE $<$<CONFIG:Debug>:/bigobj>)


### PR DESCRIPTION
Note: the build path still must remain the same between builds for this to work.