### PR TITLE
Add shebangs and tweak scripts

### DIFF
--- a/darkspore_server/build.sh
+++ b/darkspore_server/build.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 export LDFLAGS="-Wl,--copy-dt-needed-entries"
 cmake . -B build -DCMAKE_INSTALL_PREFIX=./AppDir/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -Wno-narrowing" || exit 1
 cmake --build build || exit 1
@@ -8,8 +10,13 @@ cmake -DCOMPONENT=recap_server -Pbuild/cmake_install.cmake || exit 1
 
 mkdir -p build/storage/www
 cp -r res/data build/
-cp modules/* build/ || true
-cp -r res/template_png build/storage/
-cp -r res/static build/storage/www/
 
+# Check for non-empty directory
+if [ -n "$(ls -A modules)" ]; then
+	[ -d modules ] && cp modules/* build/
+fi
+
+# Check for existing directories
+[ -d res/template_png ] && cp -r res/template_png build/storage/
+[ -d res/static ] && cp -r res/static build/storage/www/
 

--- a/darkspore_server/docker_build_and_run_server.sh
+++ b/darkspore_server/docker_build_and_run_server.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 export LDFLAGS="-Wl,--copy-dt-needed-entries"
 cmake . -B build -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations -Wno-narrowing" || exit 1
 cmake --build build || exit 1
@@ -13,5 +15,5 @@ cp modules/* build/ || true
 mkdir -p build/storage/user
 touch build/storage/user/PLACEHOLDER
 
-cd build
+cd build || exit 1
 ./recap_server --darkspore-path "./darkspore"

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,1 +1,2 @@
+#!/usr/bin/env sh
 docker-compose up

--- a/docker_clear.sh
+++ b/docker_clear.sh
@@ -1,1 +1,2 @@
-docker rm $(docker ps -a | grep recap-server | awk '{print $1;}')
+#!/usr/bin/env sh
+docker rm "$(docker ps -a | grep recap-server | awk '{print $1;}')"

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,1 +1,2 @@
-docker run -v $(pwd)/darkspore_server:/recap -P --network=host -it recap-server
+#!/usr/bin/env sh
+docker run -v "$(pwd)"/darkspore_server:/recap -P --network=host -it recap-server


### PR DESCRIPTION
This PR does the following:

1. Adds a shebang to the top of each shell script
2. Fixes some issues detected by [shellcheck](https://github.com/koalaman/shellcheck)

For the shebang, I used `/usr/bin/env sh` because the scripts do not appear to use any Bash-only features.